### PR TITLE
Integrate DocC with Bazel for CoreDTOs

### DIFF
--- a/Sources/CoreDTOs/BUILD.bazel
+++ b/Sources/CoreDTOs/BUILD.bazel
@@ -1,12 +1,48 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library", "swift_test")
 load("//:bazel/macros/swift.bzl", "umbra_swift_library")
 load("//tools/swift:build_rules.bzl", "umbracore_swift_library", "umbracore_swift_test_library")
+load("//tools/swift:docc_rules.bzl", "docc_documentation", "docc_serve")
 
 package(default_visibility = ["//visibility:public"])
 
+# DocC documentation for CoreDTOs
+docc_documentation(
+    name = "CoreDTOsDocC",
+    module_name = "CoreDTOs",
+    srcs = glob(
+        [
+            "Documentation.docc/**/*.md",
+            "Documentation.docc/**/*.docc",
+            "Documentation.docc/**/*.plist",
+            "Sources/**/*.swift",
+        ],
+        allow_empty = True,
+    ),
+    visibility = ["//visibility:public"],
+)
+
+# Simple shell script to serve the documentation 
+sh_binary(
+    name = "serve_docs",
+    srcs = ["//tools/swift:serve_docc.sh"],
+    args = ["$(location :CoreDTOsDocC)"],
+    data = [":CoreDTOsDocC"],
+)
+
+# Preview documentation 
+sh_binary(
+    name = "preview_docs",
+    srcs = ["//tools/swift:preview_docc.sh"],
+    args = ["$(location :CoreDTOsDocC)"],
+    data = [":CoreDTOsDocC"],
+)
+
 umbracore_swift_library(
     name = "CoreDTOs",
-    srcs = glob(["Sources/**/*.swift"]),
+    srcs = glob(
+        ["Sources/**/*.swift"],
+        allow_empty = True,
+    ),
     deps = [
         "//Sources/UmbraCoreTypes",
         "//Sources/ErrorHandling",
@@ -17,4 +53,7 @@ umbracore_swift_library(
     ],
     module_name = "CoreDTOs",
     visibility = ["//visibility:public"],
+    data = [
+        ":CoreDTOsDocC",
+    ],
 )

--- a/Sources/CoreDTOs/Documentation.docc/BUILD.bazel
+++ b/Sources/CoreDTOs/Documentation.docc/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//tools/swift:docc_rules.bzl", "docc_documentation")
+
+# DocC documentation for CoreDTOs
+docc_documentation(
+    name = "CoreDTOsDocC",
+    module_name = "CoreDTOs",
+    srcs = glob([
+        "*.md",
+        "*.plist",
+        "**/*.md",
+        "**/*.docc",
+        "**/*.plist",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/Sources/CoreDTOs/Documentation.docc/Info.plist
+++ b/Sources/CoreDTOs/Documentation.docc/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.umbra.CoreDTOs</string>
+    <key>CFBundleName</key>
+    <string>CoreDTOs</string>
+    <key>CFBundleDisplayName</key>
+    <string>CoreDTOs Documentation</string>
+    <key>CFBundleVersion</key>
+    <string>1.0.0</string>
+</dict>
+</plist>

--- a/tools/swift/BUILD.bazel
+++ b/tools/swift/BUILD.bazel
@@ -8,6 +8,7 @@ pkg_tar(
     srcs = [
         "build_rules.bzl",
         "compiler_options.bzl",
+        "docc_rules.bzl",
     ],
     mode = "0644",
     package_dir = "tools/swift",
@@ -19,6 +20,21 @@ filegroup(
     srcs = [
         "build_rules.bzl",
         "compiler_options.bzl",
+        "docc_rules.bzl",
     ],
     visibility = ["//visibility:public"],
 )
+
+# DocC generation executable
+sh_binary(
+    name = "docc_gen",
+    srcs = ["docc_gen.sh"],
+    visibility = ["//visibility:public"],
+)
+
+# Export DocC scripts
+exports_files([
+    "preview_docc.sh",
+    "serve_docc.sh",
+    "docc_rules.bzl",
+])

--- a/tools/swift/DocC-README.md
+++ b/tools/swift/DocC-README.md
@@ -1,0 +1,105 @@
+# DocC Documentation in UmbraCore
+
+This directory contains the tools and rules for generating and serving DocC documentation for Swift modules in UmbraCore.
+
+## Overview
+
+DocC (Documentation Compiler) is Apple's tool for creating rich, interactive documentation for Swift code. This integration enables UmbraCore to generate and serve DocC documentation as part of the Bazel build system.
+
+## Directory Structure
+
+For a module to support DocC documentation, it should have the following structure:
+
+```
+Sources/YourModule/
+  ├── Documentation.docc/
+  │   ├── YourModule.md       # Main documentation page
+  │   ├── Info.plist          # Optional configuration
+  │   ├── Resources/          # Optional resources
+  │   └── Tutorials/          # Optional tutorials
+  ├── Sources/
+  │   └── ...                 # Swift source files with DocC comments
+  └── BUILD.bazel             # Build configuration
+```
+
+## Usage
+
+### Generating Documentation
+
+To generate documentation for a module:
+
+```bash
+bazel build //Sources/YourModule:YourModuleDocC
+```
+
+This will create a `.doccarchive` file in the Bazel output directory.
+
+### Serving Documentation
+
+To serve the documentation over HTTP:
+
+```bash
+bazel run //Sources/YourModule:serve_docs
+```
+
+This will start a local web server on port 8080. You can then access the documentation by opening http://localhost:8080 in your web browser.
+
+### Previewing Documentation
+
+To preview the documentation with DocC's native preview tool (if available):
+
+```bash
+bazel run //Sources/YourModule:preview_docs
+```
+
+This will attempt to open the documentation in Xcode's DocC preview interface or, if not available, serve it via a local web server.
+
+## Customisation
+
+### Adding DocC Support to a Module
+
+To add DocC support to a Swift module, add the following to your `BUILD.bazel` file:
+
+```python
+load("//tools/swift:docc_rules.bzl", "docc_documentation")
+
+docc_documentation(
+    name = "YourModuleDocC",
+    module_name = "YourModule",
+    srcs = glob([
+        "Documentation.docc/**/*.md",
+        "Documentation.docc/**/*.docc",
+        "Documentation.docc/**/*.plist",
+        "Sources/**/*.swift",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "serve_docs",
+    srcs = ["//tools/swift:serve_docc.sh"],
+    args = ["$(location :YourModuleDocC)"],
+    data = [":YourModuleDocC"],
+)
+
+sh_binary(
+    name = "preview_docs",
+    srcs = ["//tools/swift:preview_docc.sh"],
+    args = ["$(location :YourModuleDocC)"],
+    data = [":YourModuleDocC"],
+)
+```
+
+## Troubleshooting
+
+If you encounter issues with DocC documentation generation or serving:
+
+1. Ensure all necessary source files are included in the `srcs` attribute of the `docc_documentation` rule.
+2. Check that the DocC archive was built successfully by examining the Bazel build output.
+3. If the documentation server fails to start, check that the port (8080) is not already in use.
+4. For preview issues, ensure Xcode and its command-line tools are installed correctly.
+
+## References
+
+- [Apple's DocC Documentation](https://developer.apple.com/documentation/docc)
+- [Swift-DocC GitHub Repository](https://github.com/apple/swift-docc)

--- a/tools/swift/docc_rules.bzl
+++ b/tools/swift/docc_rules.bzl
@@ -1,130 +1,422 @@
 """
-Rules for building DocC documentation within Bazel.
+Rules for generating and serving DocC documentation.
 """
 
-def _docc_archive_impl(ctx):
-    """Implementation for the docc_archive rule."""
+def _docc_documentation_impl(ctx):
+    """Implementation of docc_documentation rule."""
+    # Create output directory for DocC archive
+    docc_archive = ctx.actions.declare_directory(ctx.label.name + ".doccarchive")
     
-    output_dir = ctx.actions.declare_directory(ctx.attr.name + ".doccarchive")
+    # Create a temporary directory for DocC inputs
+    temp_dir = ctx.actions.declare_directory(ctx.label.name + "_temp")
     
-    # Create a placeholder documentation archive
-    command = """
-        set -e
-        
-        # Create a basic documentation bundle
-        mkdir -p {output}
-        
-        # Create Info.plist
-        cat > {output}/Info.plist << EOF
+    # Get all source files
+    srcs = ctx.files.srcs
+    
+    # Find docc_gen tool
+    docc_gen = ctx.executable._docc_gen
+    
+    # Find DocC tool
+    docc_tool = "/usr/bin/xcrun docc"  # Direct path to DocC tool
+    
+    # Build arguments for docc_gen
+    args = ctx.actions.args()
+    
+    # Add temp_dir argument
+    args.add("--temp_dir", temp_dir.path)
+    
+    # Add output directory argument
+    args.add("--output", docc_archive.path)
+    
+    # Add module name
+    args.add("--module_name", ctx.attr.module_name)
+    
+    # Add DocC tool path
+    args.add("--docc_tool", docc_tool)
+    
+    # Add source files
+    for src in srcs:
+        args.add("--source", src.path)
+    
+    # Add copy flag if requested
+    if ctx.attr.copy_sources:
+        args.add("--copy")
+    
+    # Execute docc_gen to generate DocC archive
+    ctx.actions.run(
+        executable = docc_gen,
+        arguments = [args],
+        inputs = srcs,
+        outputs = [temp_dir, docc_archive],
+        progress_message = "Generating DocC documentation for %s" % ctx.attr.module_name,
+        mnemonic = "DocC",
+    )
+    
+    # Return DefaultInfo provider with DocC archive
+    return [DefaultInfo(
+        files = depset([docc_archive]),
+    )]
+
+docc_documentation = rule(
+    implementation = _docc_documentation_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+            doc = "Source files for DocC documentation",
+        ),
+        "module_name": attr.string(
+            mandatory = True,
+            doc = "Name of the Swift module",
+        ),
+        "copy_sources": attr.bool(
+            default = True,
+            doc = "Whether to copy source files to temp directory",
+        ),
+        "_docc_gen": attr.label(
+            default = Label("//tools/swift:docc_gen"),
+            executable = True,
+            cfg = "host",
+        ),
+    },
+    doc = "Generate DocC documentation for a Swift module",
+)
+
+def _docc_preview_impl(ctx):
+    """Implementation of docc_preview rule."""
+    docc_archive = ctx.file.docc_archive
+    
+    script = ctx.actions.declare_file(ctx.label.name + ".sh")
+    
+    # Create a script to preview the DocC documentation
+    script_content = """#!/bin/bash
+    # Get the absolute path to the DocC archive
+    WORKSPACE_ROOT="$(pwd)"
+    DOCC_ARCHIVE_PATH="{docc_archive}"
+    
+    # If the path is not absolute, make it absolute
+    if [[ "$DOCC_ARCHIVE_PATH" != /* ]]; then
+        DOCC_ARCHIVE_PATH="$WORKSPACE_ROOT/$DOCC_ARCHIVE_PATH"
+    fi
+    
+    # Source the preview_docc script
+    source "{preview_script}" "$DOCC_ARCHIVE_PATH"
+    """.format(
+        preview_script = ctx.executable._preview_script.path,
+        docc_archive = docc_archive.path,
+    )
+    
+    ctx.actions.write(
+        output = script,
+        content = script_content,
+        is_executable = True,
+    )
+    
+    # Return runfiles for the script
+    runfiles = ctx.runfiles(files = [
+        ctx.executable._preview_script,
+        docc_archive,
+    ])
+    
+    return [DefaultInfo(
+        executable = script,
+        runfiles = runfiles,
+    )]
+
+docc_preview = rule(
+    implementation = _docc_preview_impl,
+    attrs = {
+        "docc_archive": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "DocC archive to preview",
+        ),
+        "_preview_script": attr.label(
+            default = Label("//tools/swift:preview_docc.sh"),
+            executable = True,
+            cfg = "host",
+            allow_files = True,
+        ),
+    },
+    executable = True,
+    doc = "Create a runnable target that previews DocC documentation",
+)
+
+def _docc_serve_impl(ctx):
+    """Implementation of docc_serve rule."""
+    docc_archive = ctx.file.docc_archive
+    
+    script = ctx.actions.declare_file(ctx.label.name + ".sh")
+    
+    # Create a script to serve the DocC documentation
+    script_content = """#!/bin/bash
+    # Get the absolute path to the DocC archive
+    WORKSPACE_ROOT="$(pwd)"
+    DOCC_ARCHIVE_PATH="{docc_archive}"
+    
+    # If the path is not absolute, make it absolute
+    if [[ "$DOCC_ARCHIVE_PATH" != /* ]]; then
+        DOCC_ARCHIVE_PATH="$WORKSPACE_ROOT/$DOCC_ARCHIVE_PATH"
+    fi
+    
+    # Source the serve_docc script
+    source "{serve_script}" "$DOCC_ARCHIVE_PATH"
+    """.format(
+        serve_script = ctx.executable._serve_script.path,
+        docc_archive = docc_archive.path,
+    )
+    
+    ctx.actions.write(
+        output = script,
+        content = script_content,
+        is_executable = True,
+    )
+    
+    # Return runfiles for the script
+    runfiles = ctx.runfiles(files = [
+        ctx.executable._serve_script,
+        docc_archive,
+    ])
+    
+    return [DefaultInfo(
+        executable = script,
+        runfiles = runfiles,
+    )]
+
+docc_serve = rule(
+    implementation = _docc_serve_impl,
+    attrs = {
+        "docc_archive": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "DocC archive to serve",
+        ),
+        "_serve_script": attr.label(
+            default = Label("//tools/swift:serve_docc.sh"),
+            executable = True,
+            cfg = "host",
+            allow_files = True,
+        ),
+    },
+    executable = True,
+    doc = "Create a runnable target that serves DocC documentation over HTTP",
+)
+
+def _docc_gen_impl(ctx):
+    """Implementation for the docc_gen executable rule."""
+    script = ctx.actions.declare_file(ctx.label.name + ".sh")
+    
+    script_content = """#!/bin/bash
+    set -e
+    
+    # Parse arguments
+    TEMP_DIR=""
+    OUTPUT=""
+    MODULE_NAME=""
+    DOCC_TOOL=""
+    SOURCES=()
+    
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --copy)
+                # --copy flag is just a marker for copy operation, no value needed
+                shift
+                ;;
+            --temp_dir)
+                TEMP_DIR="$2"
+                shift 2
+                ;;
+            --output)
+                OUTPUT="$2"
+                shift 2
+                ;;
+            --module_name)
+                MODULE_NAME="$2"
+                shift 2
+                ;;
+            --docc_tool)
+                DOCC_TOOL="$2"
+                shift 2
+                ;;
+            --source)
+                SOURCES+=("$2")
+                shift 2
+                ;;
+            *)
+                echo "Unknown argument: $1"
+                exit 1
+                ;;
+        esac
+    done
+    
+    # Check required arguments
+    if [ -z "$TEMP_DIR" ]; then
+        echo "Error: --temp_dir is required"
+        exit 1
+    fi
+    
+    if [ -z "$OUTPUT" ]; then
+        echo "Error: --output is required"
+        exit 1
+    fi
+    
+    if [ -z "$MODULE_NAME" ]; then
+        echo "Error: --module_name is required"
+        exit 1
+    fi
+    
+    if [ -z "$DOCC_TOOL" ]; then
+        echo "Error: --docc_tool is required"
+        exit 1
+    fi
+    
+    # Create temporary directory structure
+    mkdir -p "$TEMP_DIR/Documentation.docc"
+    mkdir -p "$TEMP_DIR/Sources"
+    
+    # Default documentation catalog if none provided
+    if [ ! -f "$TEMP_DIR/Documentation.docc/Info.plist" ]; then
+        cat > "$TEMP_DIR/Documentation.docc/Info.plist" << EOL
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>CFBundleIdentifier</key>
-    <string>com.umbra.{module}</string>
+    <string>$MODULE_NAME</string>
     <key>CFBundleName</key>
-    <string>{module}</string>
-    <key>CFBundleDisplayName</key>
-    <string>{module} Documentation</string>
+    <string>$MODULE_NAME</string>
     <key>CFBundleVersion</key>
     <string>1.0.0</string>
+    <key>CDDefaultCodeListingLanguage</key>
+    <string>swift</string>
 </dict>
 </plist>
-EOF
+EOL
+    fi
+    
+    # Create default module documentation file
+    if [ ! -f "$TEMP_DIR/Documentation.docc/$MODULE_NAME.md" ]; then
+        cat > "$TEMP_DIR/Documentation.docc/$MODULE_NAME.md" << EOL
+# ``$MODULE_NAME``
+
+Documentation for the $MODULE_NAME module.
+
+## Overview
+
+This is the documentation for the $MODULE_NAME module. This documentation was generated using Apple's DocC and Bazel.
+
+## Topics
+
+### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+
+- <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->
+EOL
+    fi
+    
+    # Copy source files to temp directory
+    echo "Copying source files to temporary directory..."
+    for src in "${SOURCES[@]}"; do
+        # Skip non-Swift files in source directories
+        if [[ "$src" == *"/Sources/"* && ! "$src" == *.swift ]]; then
+            continue
+        fi
         
-        # Create index.html
-        mkdir -p {output}/documentation
-        cat > {output}/documentation/index.html << EOF
+        # Determine the destination based on the source path
+        if [[ "$src" == *"/Documentation.docc/"* ]]; then
+            # Extract the part after Documentation.docc/
+            rel_path=$(echo "$src" | awk -F "/Documentation.docc/" '{print $2}')
+            dst="$TEMP_DIR/Documentation.docc/$rel_path"
+        elif [[ "$src" == *"/Sources/"* ]]; then
+            # Extract the part after /Sources/
+            rel_path=$(echo "$src" | awk -F "/Sources/" '{print $2}')
+            dst="$TEMP_DIR/Sources/$rel_path"
+        else
+            # For other files, place them at the root of temp dir
+            dst="$TEMP_DIR/$(basename "$src")"
+        fi
+        
+        # Create directory if needed
+        mkdir -p "$(dirname "$dst")"
+        
+        # Copy the file
+        cp "$src" "$dst"
+    done
+    
+    # Show what we've got
+    echo "Contents of temporary directory:"
+    find "$TEMP_DIR" -type f | sort
+    
+    # Check if we have source files
+    if [ -d "$TEMP_DIR/Sources" ] && [ "$(find "$TEMP_DIR/Sources" -name "*.swift" | wc -l)" -gt 0 ]; then
+        echo "Found source files in $TEMP_DIR/Sources"
+    else
+        echo "Warning: No Swift source files found in $TEMP_DIR/Sources"
+    fi
+    
+    # Generate documentation
+    echo "Approach 1: Using DocC convert directly..."
+    if "$DOCC_TOOL" convert "$TEMP_DIR/Documentation.docc" \\
+        --output-path "$OUTPUT" \\
+        --fallback-display-name "$MODULE_NAME" \\
+        --fallback-bundle-identifier "com.umbreproject.$MODULE_NAME" \\
+        --fallback-bundle-version "1.0.0" \\
+        --additional-symbol-graph-dir "$TEMP_DIR/Sources" \\
+        --transform-for-static-hosting; then
+        
+        echo "DocC conversion succeeded!"
+        
+        # Process archive for static hosting
+        echo "Processing archive for static hosting..."
+        # Ensure index.html is present for static hosting
+        if [ ! -f "$OUTPUT/index.html" ]; then
+            cat > "$OUTPUT/index.html" << EOL
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{module} Documentation</title>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta http-equiv="refresh" content="0;URL='documentation/index.html'" />
 </head>
 <body>
-    <h1>{module} Documentation</h1>
-    <p>This is a placeholder for the {module} documentation.</p>
-    <p>Full documentation will be generated in a future update.</p>
+    <p>Redirecting to documentation...</p>
 </body>
 </html>
-EOF
-    """.format(
-        module = ctx.attr.module_name,
-        output = output_dir.path,
+EOL
+        fi
+        
+        echo "Successfully processed archive, copying back to output directory"
+        
+    else
+        echo "DocC conversion failed with approach 1, trying alternative approach..."
+        # Alternative approach using old-style arguments
+        "$DOCC_TOOL" \\
+            --output-path "$OUTPUT" \\
+            --bundle-identifier "com.umbreproject.$MODULE_NAME" \\
+            --fallback-display-name "$MODULE_NAME" \\
+            --fallback-bundle-version "1.0.0" \\
+            --additional-symbol-graph-dir "$TEMP_DIR/Sources" \\
+            --transform-for-static-hosting \\
+            "$TEMP_DIR/Documentation.docc"
+            
+        if [ $? -eq 0 ]; then
+            echo "Alternative DocC conversion succeeded!"
+        else
+            echo "All DocC conversion approaches failed"
+            exit 1
+        fi
+    fi
+    """
+    
+    ctx.actions.write(
+        output = script,
+        content = script_content,
+        is_executable = True,
     )
     
-    # Execute the command
-    ctx.actions.run_shell(
-        inputs = ctx.files.srcs,
-        outputs = [output_dir],
-        command = command,
-        mnemonic = "DoCCGenerate",
-        progress_message = "Generating DocC documentation for %s" % ctx.attr.module_name,
-    )
-    
-    return [DefaultInfo(files = depset([output_dir]))]
+    return [DefaultInfo(
+        executable = script,
+        files = depset([script]),
+    )]
 
-docc_archive = rule(
-    implementation = _docc_archive_impl,
-    attrs = {
-        "srcs": attr.label_list(
-            allow_files = True,
-            doc = "Source files for the module",
-        ),
-        "module_name": attr.string(
-            mandatory = True,
-            doc = "Name of the Swift module to document",
-        ),
-        "sdk": attr.string(
-            default = "macosx",
-            doc = "SDK to use for symbol graph generation",
-        ),
-        "target": attr.string(
-            doc = "Target to use for symbol graph generation",
-        ),
-        "product_name": attr.string(
-            doc = "Product name to use for documentation",
-        ),
-    },
+docc_gen = rule(
+    implementation = _docc_gen_impl,
+    executable = True,
+    doc = "Create an executable that generates DocC documentation",
 )
-
-def docc_documentation(name, module_name, srcs, **kwargs):
-    """
-    Generate DocC documentation for a Swift module.
-    
-    Args:
-        name: Name of the rule
-        module_name: Name of the Swift module to document
-        srcs: Source files for the module
-        **kwargs: Additional arguments
-    """
-    
-    docc_archive(
-        name = name,
-        module_name = module_name,
-        srcs = srcs,
-        **kwargs
-    )
-    
-    # Rule to host the documentation for local preview
-    native.sh_binary(
-        name = name + "_preview",
-        srcs = ["preview_docc.sh"],
-        data = [":" + name],
-    )
-
-def docc_serve(name, docc_archive):
-    """
-    Create a rule to serve a DocC archive.
-    
-    Args:
-        name: Name of the rule
-        docc_archive: DocC archive to serve
-    """
-    
-    native.sh_binary(
-        name = name,
-        srcs = ["serve_docc.sh"],
-        data = [docc_archive],
-    )


### PR DESCRIPTION
- Modified docc_rules.bzl to improve DocC generation and serving
- Created and updated serve_docc.sh and preview_docc.sh scripts
- Updated BUILD.bazel files to use Bazel's sh_binary for better integration
- Added comprehensive DocC-README.md with integration instructions
- Fixed path discovery and error handling in scripts
- Set up direct DocC archive generation with comprehensive file handling