### PR TITLE
fix: Resolve ServicesDTOAdapter build errors and improve Void handling

### DIFF
--- a/Sources/CoreDTOs/Documentation.docc/BUILD.bazel
+++ b/Sources/CoreDTOs/Documentation.docc/BUILD.bazel
@@ -10,6 +10,6 @@ docc_documentation(
         "**/*.md",
         "**/*.docc",
         "**/*.plist",
-    ]),
+    ], allow_empty = True),
     visibility = ["//visibility:public"],
 )

--- a/Sources/CoreDTOs/Sources/Operations/OperationResultDTO.swift
+++ b/Sources/CoreDTOs/Sources/Operations/OperationResultDTO.swift
@@ -245,3 +245,17 @@ public struct OperationResultDTO<T>: Sendable, Equatable where T: Sendable, T: E
         )
     }
 }
+
+// MARK: - VoidEquatable Wrapper
+
+/// A wrapper for Void that conforms to Equatable
+/// This allows OperationResultDTO to be used with Void as a type parameter
+public struct VoidEquatable: Sendable, Equatable {
+    /// Creates a new VoidEquatable
+    public init() {}
+    
+    /// Equality check for VoidEquatable
+    public static func == (lhs: VoidEquatable, rhs: VoidEquatable) -> Bool {
+        return true
+    }
+}

--- a/Sources/Features/Logging/Services/LoggingService.swift
+++ b/Sources/Features/Logging/Services/LoggingService.swift
@@ -113,7 +113,7 @@ public actor LoggingService {
             .Core
     ) -> ErrorHandlingDomains.UmbraErrors.Security.Protocols {
         switch error {
-        case let .storageOperationFailed(operation: _, reason: reason):
+        case let .storageOperationFailed(reason):
             return .invalidInput("Bookmark error: \(reason)")
         case let .internalError(reason):
             return .internalError(reason)

--- a/Sources/Services/ServicesDTOAdapter/CredentialManagerDTOAdapter.swift
+++ b/Sources/Services/ServicesDTOAdapter/CredentialManagerDTOAdapter.swift
@@ -35,20 +35,28 @@ public struct CredentialManagerDTOAdapter {
     public func storeCredential(
         _ credential: [UInt8],
         config: SecurityConfigDTO
-    ) async throws -> OperationResultDTO<Void> {
+    ) async throws -> OperationResultDTO<VoidEquatable> {
         do {
             // Extract service and account from config options
             guard let service = config.options["service"],
                   let account = config.options["account"]
             else {
                 return .failure(
-                    .init(
-                        error: SecurityErrorDTO.storageError(
-                            message: "Missing service or account in configuration",
-                            details: ["service": config.options["service"] ?? "missing",
-                                      "account": config.options["account"] ?? "missing"]
-                        )
-                    )
+                    errorCode: SecurityErrorDTO.storageError(
+                        message: "Missing service or account in configuration",
+                        details: ["service": config.options["service"] ?? "missing",
+                                  "account": config.options["account"] ?? "missing"]
+                    ).code,
+                    errorMessage: SecurityErrorDTO.storageError(
+                        message: "Missing service or account in configuration",
+                        details: ["service": config.options["service"] ?? "missing",
+                                  "account": config.options["account"] ?? "missing"]
+                    ).message,
+                    details: SecurityErrorDTO.storageError(
+                        message: "Missing service or account in configuration",
+                        details: ["service": config.options["service"] ?? "missing",
+                                  "account": config.options["account"] ?? "missing"]
+                    ).details
                 )
             }
 
@@ -59,11 +67,15 @@ public struct CredentialManagerDTOAdapter {
             try await credentialManager.store(credentialData, service: service, account: account)
 
             // Return success
-            return .success(())
+            return .success(VoidEquatable())
         } catch let error as CredentialError {
             // Map CredentialError to SecurityErrorDTO
             let securityError = mapCredentialError(error)
-            return .failure(.init(error: securityError))
+            return .failure(
+                errorCode: securityError.code,
+                errorMessage: securityError.message,
+                details: securityError.details
+            )
         } catch {
             // Map other errors to SecurityErrorDTO
             let securityError = SecurityErrorDTO(
@@ -72,7 +84,11 @@ public struct CredentialManagerDTOAdapter {
                 message: "Unknown credential error: \(error.localizedDescription)",
                 details: ["originalError": "\(error)"]
             )
-            return .failure(.init(error: securityError))
+            return .failure(
+                errorCode: securityError.code,
+                errorMessage: securityError.message,
+                details: securityError.details
+            )
         }
     }
 
@@ -88,13 +104,21 @@ public struct CredentialManagerDTOAdapter {
                   let account = config.options["account"]
             else {
                 return .failure(
-                    .init(
-                        error: SecurityErrorDTO.storageError(
-                            message: "Missing service or account in configuration",
-                            details: ["service": config.options["service"] ?? "missing",
-                                      "account": config.options["account"] ?? "missing"]
-                        )
-                    )
+                    errorCode: SecurityErrorDTO.storageError(
+                        message: "Missing service or account in configuration",
+                        details: ["service": config.options["service"] ?? "missing",
+                                  "account": config.options["account"] ?? "missing"]
+                    ).code,
+                    errorMessage: SecurityErrorDTO.storageError(
+                        message: "Missing service or account in configuration",
+                        details: ["service": config.options["service"] ?? "missing",
+                                  "account": config.options["account"] ?? "missing"]
+                    ).message,
+                    details: SecurityErrorDTO.storageError(
+                        message: "Missing service or account in configuration",
+                        details: ["service": config.options["service"] ?? "missing",
+                                  "account": config.options["account"] ?? "missing"]
+                    ).details
                 )
             }
 
@@ -109,7 +133,11 @@ public struct CredentialManagerDTOAdapter {
         } catch let error as CredentialError {
             // Map CredentialError to SecurityErrorDTO
             let securityError = mapCredentialError(error)
-            return .failure(.init(error: securityError))
+            return .failure(
+                errorCode: securityError.code,
+                errorMessage: securityError.message,
+                details: securityError.details
+            )
         } catch {
             // Map other errors to SecurityErrorDTO
             let securityError = SecurityErrorDTO(
@@ -118,7 +146,11 @@ public struct CredentialManagerDTOAdapter {
                 message: "Unknown credential error: \(error.localizedDescription)",
                 details: ["originalError": "\(error)"]
             )
-            return .failure(.init(error: securityError))
+            return .failure(
+                errorCode: securityError.code,
+                errorMessage: securityError.message,
+                details: securityError.details
+            )
         }
     }
 
@@ -127,20 +159,28 @@ public struct CredentialManagerDTOAdapter {
     /// - Returns: A result indicating success or failure
     public func deleteCredential(
         config: SecurityConfigDTO
-    ) async throws -> OperationResultDTO<Void> {
+    ) async throws -> OperationResultDTO<VoidEquatable> {
         do {
             // Extract service and account from config options
             guard let service = config.options["service"],
                   let account = config.options["account"]
             else {
                 return .failure(
-                    .init(
-                        error: SecurityErrorDTO.storageError(
-                            message: "Missing service or account in configuration",
-                            details: ["service": config.options["service"] ?? "missing",
-                                      "account": config.options["account"] ?? "missing"]
-                        )
-                    )
+                    errorCode: SecurityErrorDTO.storageError(
+                        message: "Missing service or account in configuration",
+                        details: ["service": config.options["service"] ?? "missing",
+                                  "account": config.options["account"] ?? "missing"]
+                    ).code,
+                    errorMessage: SecurityErrorDTO.storageError(
+                        message: "Missing service or account in configuration",
+                        details: ["service": config.options["service"] ?? "missing",
+                                  "account": config.options["account"] ?? "missing"]
+                    ).message,
+                    details: SecurityErrorDTO.storageError(
+                        message: "Missing service or account in configuration",
+                        details: ["service": config.options["service"] ?? "missing",
+                                  "account": config.options["account"] ?? "missing"]
+                    ).details
                 )
             }
 
@@ -148,11 +188,15 @@ public struct CredentialManagerDTOAdapter {
             try await credentialManager.delete(service: service, account: account)
 
             // Return success
-            return .success(())
+            return .success(VoidEquatable())
         } catch let error as CredentialError {
             // Map CredentialError to SecurityErrorDTO
             let securityError = mapCredentialError(error)
-            return .failure(.init(error: securityError))
+            return .failure(
+                errorCode: securityError.code,
+                errorMessage: securityError.message,
+                details: securityError.details
+            )
         } catch {
             // Map other errors to SecurityErrorDTO
             let securityError = SecurityErrorDTO(
@@ -161,7 +205,11 @@ public struct CredentialManagerDTOAdapter {
                 message: "Unknown credential error: \(error.localizedDescription)",
                 details: ["originalError": "\(error)"]
             )
-            return .failure(.init(error: securityError))
+            return .failure(
+                errorCode: securityError.code,
+                errorMessage: securityError.message,
+                details: securityError.details
+            )
         }
     }
 
@@ -223,20 +271,20 @@ public protocol CredentialManaging: AnyActor {
     ///   - credential: The credential to store
     ///   - service: The service identifier
     ///   - account: The account identifier
-    func store(_ credential: Data, service: String, account: String) throws
+    func store(_ credential: Data, service: String, account: String) async throws
 
     /// Retrieve a credential
     /// - Parameters:
     ///   - service: The service identifier
     ///   - account: The account identifier
     /// - Returns: The credential data
-    func retrieve(service: String, account: String) throws -> Data
+    func retrieve(service: String, account: String) async throws -> Data
 
     /// Delete a credential
     /// - Parameters:
     ///   - service: The service identifier
     ///   - account: The account identifier
-    func delete(service: String, account: String) throws
+    func delete(service: String, account: String) async throws
 }
 
 // MARK: - CredentialError
@@ -280,7 +328,7 @@ public final actor CredentialManager: CredentialManaging {
     ///   - credential: The credential to store
     ///   - service: The service identifier
     ///   - account: The account identifier
-    public func store(_ credential: Data, service: String, account: String) throws {
+    public func store(_ credential: Data, service: String, account: String) async throws {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -299,7 +347,7 @@ public final actor CredentialManager: CredentialManaging {
     ///   - service: The service identifier
     ///   - account: The account identifier
     /// - Returns: The stored credential
-    public func retrieve(service: String, account: String) throws -> Data {
+    public func retrieve(service: String, account: String) async throws -> Data {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -325,7 +373,7 @@ public final actor CredentialManager: CredentialManaging {
     /// - Parameters:
     ///   - service: The service identifier
     ///   - account: The account identifier
-    public func delete(service: String, account: String) throws {
+    public func delete(service: String, account: String) async throws {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,

--- a/Sources/Services/ServicesDTOAdapter/SecurityUtilsDTOAdapter.swift
+++ b/Sources/Services/ServicesDTOAdapter/SecurityUtilsDTOAdapter.swift
@@ -41,24 +41,18 @@ public struct SecurityUtilsDTOAdapter {
 
             guard result == errSecSuccess else {
                 return .failure(
-                    .init(
-                        error: SecurityErrorDTO.keyError(
-                            message: "Failed to generate random key",
-                            details: ["osStatus": "\(result)"]
-                        )
-                    )
+                    errorCode: 1001, // Using the key error code from SecurityErrorDTO
+                    errorMessage: "Failed to generate random key",
+                    details: ["osStatus": "\(result)"]
                 )
             }
 
             return .success(keyData)
         } catch {
             return .failure(
-                .init(
-                    error: SecurityErrorDTO.keyError(
-                        message: "Unknown error generating key: \(error.localizedDescription)",
-                        details: ["error": "\(error)"]
-                    )
-                )
+                errorCode: 1001, // Using the key error code from SecurityErrorDTO
+                errorMessage: "Unknown error generating key: \(error.localizedDescription)",
+                details: ["error": "\(error)"]
             )
         }
     }
@@ -88,14 +82,9 @@ public struct SecurityUtilsDTOAdapter {
             return .success(hashBytes)
         } catch {
             return .failure(
-                .init(
-                    error: SecurityErrorDTO(
-                        code: Int32(error._code),
-                        domain: "security.hash",
-                        message: "Failed to hash data: \(error.localizedDescription)",
-                        details: ["algorithm": config.algorithm]
-                    )
-                )
+                errorCode: 1002, // Using the hash error code from SecurityErrorDTO
+                errorMessage: "Failed to hash data: \(error.localizedDescription)",
+                details: ["algorithm": config.algorithm]
             )
         }
     }
@@ -119,24 +108,18 @@ public struct SecurityUtilsDTOAdapter {
             // Check if we have a key in the options
             guard let keyBase64 = config.options["key"] else {
                 return .failure(
-                    .init(
-                        error: SecurityErrorDTO.encryptionError(
-                            message: "Missing encryption key in configuration",
-                            details: ["algorithm": algorithm]
-                        )
-                    )
+                    errorCode: 1003, // Using the encryption error code from SecurityErrorDTO
+                    errorMessage: "Missing encryption key in configuration",
+                    details: ["algorithm": algorithm]
                 )
             }
 
             // Convert key from Base64
             guard let keyData = Data(base64Encoded: keyBase64) else {
                 return .failure(
-                    .init(
-                        error: SecurityErrorDTO.encryptionError(
-                            message: "Invalid encryption key format",
-                            details: ["algorithm": algorithm]
-                        )
-                    )
+                    errorCode: 1003, // Using the encryption error code from SecurityErrorDTO
+                    errorMessage: "Invalid encryption key format",
+                    details: ["algorithm": algorithm]
                 )
             }
 
@@ -149,12 +132,9 @@ public struct SecurityUtilsDTOAdapter {
             return .success(encryptedBytes)
         } catch {
             return .failure(
-                .init(
-                    error: SecurityErrorDTO.encryptionError(
-                        message: "Failed to encrypt data: \(error.localizedDescription)",
-                        details: ["algorithm": config.algorithm]
-                    )
-                )
+                errorCode: 1003, // Using the encryption error code from SecurityErrorDTO
+                errorMessage: "Failed to encrypt data: \(error.localizedDescription)",
+                details: ["algorithm": config.algorithm]
             )
         }
     }
@@ -178,24 +158,18 @@ public struct SecurityUtilsDTOAdapter {
             // Check if we have a key in the options
             guard let keyBase64 = config.options["key"] else {
                 return .failure(
-                    .init(
-                        error: SecurityErrorDTO.decryptionError(
-                            message: "Missing decryption key in configuration",
-                            details: ["algorithm": algorithm]
-                        )
-                    )
+                    errorCode: 1004, // Using the decryption error code from SecurityErrorDTO
+                    errorMessage: "Missing decryption key in configuration",
+                    details: ["algorithm": algorithm]
                 )
             }
 
             // Convert key from Base64
             guard let keyData = Data(base64Encoded: keyBase64) else {
                 return .failure(
-                    .init(
-                        error: SecurityErrorDTO.decryptionError(
-                            message: "Invalid decryption key format",
-                            details: ["algorithm": algorithm]
-                        )
-                    )
+                    errorCode: 1004, // Using the decryption error code from SecurityErrorDTO
+                    errorMessage: "Invalid decryption key format",
+                    details: ["algorithm": algorithm]
                 )
             }
 
@@ -208,12 +182,9 @@ public struct SecurityUtilsDTOAdapter {
             return .success(decryptedBytes)
         } catch {
             return .failure(
-                .init(
-                    error: SecurityErrorDTO.decryptionError(
-                        message: "Failed to decrypt data: \(error.localizedDescription)",
-                        details: ["algorithm": config.algorithm]
-                    )
-                )
+                errorCode: 1004, // Using the decryption error code from SecurityErrorDTO
+                errorMessage: "Failed to decrypt data: \(error.localizedDescription)",
+                details: ["algorithm": config.algorithm]
             )
         }
     }

--- a/Sources/Services/ServicesDTOAdapter/ServicesErrorAdapter.swift
+++ b/Sources/Services/ServicesDTOAdapter/ServicesErrorAdapter.swift
@@ -72,7 +72,7 @@ public enum ServicesErrorAdapter {
         let errorDetails = extractSecurityErrorDetails(error)
 
         // Create appropriate error message based on error code
-        var errorMessage: String
+        let errorMessage: String
 
             // Map common security error codes
             = switch errorCode
@@ -148,7 +148,7 @@ public enum ServicesErrorAdapter {
         details["errorDomain"] = error._domain
 
         // Extract specific information for certain error types
-        if let nsError = error as NSError {
+        if let nsError = error as? NSError {
             // Add userInfo keys that might be useful
             if let failureReason = nsError.localizedFailureReason {
                 details["failureReason"] = failureReason
@@ -178,7 +178,7 @@ public enum ServicesErrorAdapter {
         details["errorDomain"] = error._domain
 
         // Extract specific information for certain error types
-        if let nsError = error as NSError {
+        if let nsError = error as? NSError {
             // Add userInfo keys that might be useful
             if let failureReason = nsError.localizedFailureReason {
                 details["failureReason"] = failureReason


### PR DESCRIPTION
- Add VoidEquatable wrapper to enable OperationResultDTO with Void returns
- Update CredentialManagerDTOAdapter to use VoidEquatable instead of Void
- Make CredentialManaging protocol methods async to match actor-isolated implementations
- Fix tuple pattern in LoggingService error mapping
- Update Documentation.docc BUILD file to allow empty globs

These changes fix several build errors:
1. "type 'Void' does not conform to protocol 'Equatable'" in OperationResultDTO
2. "actor-isolated instance method cannot be used to satisfy nonisolated protocol requirement" in CredentialManager
3. "tuple pattern has the wrong length" error in LoggingService

Part of ongoing work to eliminate type aliases and improve type safety across the UmbraCore project.