### PR TITLE
refactor: Replace Foundation types with CoreDTOs in test mocks

### DIFF
--- a/Examples/Services/ServicesDTOExample.swift
+++ b/Examples/Services/ServicesDTOExample.swift
@@ -49,10 +49,18 @@ public struct ServicesDTOExample {
         print("Generated sample credential bytes: \(sampleCredential.count) bytes")
 
         // Store the credential
+        let storeConfig = SecurityConfigDTO(
+            algorithm: "keychain",
+            keySizeInBits: 0,
+            options: [
+                "service": "com.umbra.example",
+                "account": "test-user"
+            ]
+        )
+        
         let storeResult = credentialAdapter.storeCredential(
             sampleCredential,
-            service: "com.umbra.example",
-            account: "test-user"
+            config: storeConfig
         )
 
         switch storeResult {
@@ -60,9 +68,17 @@ public struct ServicesDTOExample {
             print("✅ Successfully stored credential")
 
             // Retrieve the credential
+            let retrieveConfig = SecurityConfigDTO(
+                algorithm: "keychain",
+                keySizeInBits: 0,
+                options: [
+                    "service": "com.umbra.example",
+                    "account": "test-user"
+                ]
+            )
+            
             let retrieveResult = credentialAdapter.retrieveCredential(
-                service: "com.umbra.example",
-                account: "test-user"
+                config: retrieveConfig
             )
 
             switch retrieveResult {
@@ -70,9 +86,17 @@ public struct ServicesDTOExample {
                 print("✅ Successfully retrieved credential: \(retrievedCredential.count) bytes")
 
                 // Delete the credential
+                let deleteConfig = SecurityConfigDTO(
+                    algorithm: "keychain",
+                    keySizeInBits: 0,
+                    options: [
+                        "service": "com.umbra.example",
+                        "account": "test-user"
+                    ]
+                )
+                
                 let deleteResult = credentialAdapter.deleteCredential(
-                    service: "com.umbra.example",
-                    account: "test-user"
+                    config: deleteConfig
                 )
 
                 switch deleteResult {
@@ -191,9 +215,17 @@ public struct ServicesDTOExample {
         // Example of credential error handling
         do {
             // Attempt to retrieve a non-existent credential
+            let nonExistentConfig = SecurityConfigDTO(
+                algorithm: "keychain",
+                keySizeInBits: 0,
+                options: [
+                    "service": "com.umbra.nonexistent",
+                    "account": "nobody"
+                ]
+            )
+            
             let result = credentialAdapter.retrieveCredential(
-                service: "com.umbra.nonexistent",
-                account: "nobody"
+                config: nonExistentConfig
             )
 
             switch result {

--- a/Sources/Core/Services/CryptoService.swift
+++ b/Sources/Core/Services/CryptoService.swift
@@ -77,10 +77,10 @@ public actor CryptoService: UmbraService {
     public static let serviceIdentifier = "com.umbracore.crypto"
 
     /// The internal state of the service.
-    private var _state: ServiceState = .uninitialized
+    private var _state: CoreServicesTypes.ServiceState = .uninitialized
 
     /// The current state of the service, accessible from any context.
-    public private(set) nonisolated(unsafe) var state: ServiceState = .uninitialized
+    public private(set) nonisolated(unsafe) var state: CoreServicesTypes.ServiceState = .uninitialized
 
     /// The configuration for cryptographic operations.
     private let config: CryptoTypes.CryptoConfig

--- a/Tests/UmbraTestKit/TestKit/Extensions/SecurityExtensions.swift
+++ b/Tests/UmbraTestKit/TestKit/Extensions/SecurityExtensions.swift
@@ -1,6 +1,7 @@
 import ErrorHandlingDomains
 import Foundation
 import SecurityInterfaces
+import SecurityProtocolsCore
 import SecurityTypes
 
 // Define a protocol for URL-based security access
@@ -12,7 +13,7 @@ public protocol URLSecurityProvider {
     func startAccessing(url: URL) async throws -> Bool
 }
 
-public extension SecurityInterfaces.SecurityProvider {
+public extension SecurityProtocolsCore.SecurityProviderProtocol {
     /// Start accessing a URL security-scoped resource
     /// - Parameter url: URL to access
     /// - Returns: True if access was granted
@@ -20,8 +21,23 @@ public extension SecurityInterfaces.SecurityProvider {
     func startAccessing(url: URL) async throws -> Bool {
         // Access the path directly to avoid recursive call
         guard !url.path.isEmpty else {
-            throw SecurityInterfaces.SecurityError.operationFailed("Empty path")
+            throw ErrorHandlingDomains.UmbraErrors.Security.Protocols
+                .makeInvalidInput(message: "Empty path")
         }
         return true
+    }
+    
+    /// Performs an operation with security-scoped access to a path
+    /// - Parameters:
+    ///   - path: The path to access with security scope
+    ///   - operation: The operation to perform while access is granted
+    /// - Returns: The result of the operation
+    /// - Throws: An error if access could not be granted or if the operation fails
+    func withSecurityScopedAccess<T: Sendable>(
+        to path: String,
+        perform operation: @Sendable () async throws -> T
+    ) async throws -> T {
+        // Mock implementation that always grants access
+        return try await operation()
     }
 }

--- a/Tests/UmbraTestKit/TestKit/Mocks/MockCryptoService.swift
+++ b/Tests/UmbraTestKit/TestKit/Mocks/MockCryptoService.swift
@@ -1,13 +1,77 @@
 import CryptoTypes
 import CryptoTypesProtocols
+import ErrorHandlingDomains
 import Foundation
+import SecurityProtocolsCore
+import UmbraCoreTypes
 
-public actor MockCryptoService: CryptoServiceProtocol {
+public actor MockCryptoService: SecurityProtocolsCore.CryptoServiceProtocol {
     private var encryptedData: [String: Data] = [:]
     private var decryptedData: [String: Data] = [:]
 
     public init() {}
 
+    // MARK: - CryptoServiceProtocol Methods
+    
+    public func encrypt(data: UmbraCoreTypes.SecureBytes, using key: UmbraCoreTypes.SecureBytes) async -> Result<UmbraCoreTypes.SecureBytes, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        return .success(data) // Mock implementation just returns the data
+    }
+    
+    public func decrypt(data: UmbraCoreTypes.SecureBytes, using key: UmbraCoreTypes.SecureBytes) async -> Result<UmbraCoreTypes.SecureBytes, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        return .success(data) // Mock implementation just returns the data
+    }
+    
+    public func generateKey() async -> Result<UmbraCoreTypes.SecureBytes, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        let bytes = Array(repeating: UInt8(0), count: 32)
+        return .success(UmbraCoreTypes.SecureBytes(bytes: bytes))
+    }
+    
+    public func hash(data: UmbraCoreTypes.SecureBytes) async -> Result<UmbraCoreTypes.SecureBytes, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        let bytes = Array(repeating: UInt8(0), count: 32)
+        return .success(UmbraCoreTypes.SecureBytes(bytes: bytes))
+    }
+    
+    public func verify(data: UmbraCoreTypes.SecureBytes, against hash: UmbraCoreTypes.SecureBytes) async -> Result<Bool, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        return .success(true)
+    }
+    
+    public func encryptSymmetric(data: UmbraCoreTypes.SecureBytes, key: UmbraCoreTypes.SecureBytes, config: SecurityProtocolsCore.SecurityConfigDTO) async -> Result<UmbraCoreTypes.SecureBytes, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        return .success(data)
+    }
+    
+    public func decryptSymmetric(data: UmbraCoreTypes.SecureBytes, key: UmbraCoreTypes.SecureBytes, config: SecurityProtocolsCore.SecurityConfigDTO) async -> Result<UmbraCoreTypes.SecureBytes, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        return .success(data)
+    }
+    
+    public func encryptAsymmetric(data: UmbraCoreTypes.SecureBytes, publicKey: UmbraCoreTypes.SecureBytes, config: SecurityProtocolsCore.SecurityConfigDTO) async -> Result<UmbraCoreTypes.SecureBytes, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        return .success(data)
+    }
+    
+    public func decryptAsymmetric(data: UmbraCoreTypes.SecureBytes, privateKey: UmbraCoreTypes.SecureBytes, config: SecurityProtocolsCore.SecurityConfigDTO) async -> Result<UmbraCoreTypes.SecureBytes, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        return .success(data)
+    }
+    
+    public func hash(data: UmbraCoreTypes.SecureBytes, config: SecurityProtocolsCore.SecurityConfigDTO) async -> Result<UmbraCoreTypes.SecureBytes, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        let bytes = Array(repeating: UInt8(0), count: 32)
+        return .success(UmbraCoreTypes.SecureBytes(bytes: bytes))
+    }
+    
+    public func sign(data: UmbraCoreTypes.SecureBytes, privateKey: UmbraCoreTypes.SecureBytes, config: SecurityProtocolsCore.SecurityConfigDTO) async -> Result<UmbraCoreTypes.SecureBytes, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        let bytes = Array(repeating: UInt8(0), count: 64)
+        return .success(UmbraCoreTypes.SecureBytes(bytes: bytes))
+    }
+    
+    public func verify(signature: UmbraCoreTypes.SecureBytes, data: UmbraCoreTypes.SecureBytes, publicKey: UmbraCoreTypes.SecureBytes, config: SecurityProtocolsCore.SecurityConfigDTO) async -> Result<Bool, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        return .success(true)
+    }
+    
+    public func generateRandomData(length: Int) async -> Result<UmbraCoreTypes.SecureBytes, ErrorHandlingDomains.UmbraErrors.Security.Protocols> {
+        let bytes = Array(repeating: UInt8(0), count: length)
+        return .success(UmbraCoreTypes.SecureBytes(bytes: bytes))
+    }
+    
+    // MARK: - Legacy Methods
+    
     public func encrypt(_ data: Data, using key: Data, iv: Data) async throws -> Data {
         let identifier = "\(key.hashValue):\(iv.hashValue)"
         encryptedData[identifier] = data

--- a/Tests/UmbraTestKit/TestKit/Mocks/MockKeychain.swift
+++ b/Tests/UmbraTestKit/TestKit/Mocks/MockKeychain.swift
@@ -20,35 +20,35 @@ public actor MockKeychain: SecureStorageProvider {
 
     public func load(forKey key: String) async throws -> Data {
         guard let data = storage[key] else {
-            throw SecurityInterfaces.SecurityError.operationFailed("No data found for key: \(key)")
+            throw ErrorHandlingDomains.UmbraErrors.Security.Protocols.makeStorageOperationFailed(message: "No data found for key: \(key)")
         }
         return data
     }
 
     public func loadWithMetadata(forKey key: String) async throws -> (Data, [String: String]?) {
         guard let data = storage[key] else {
-            throw SecurityInterfaces.SecurityError.operationFailed("No data found for key: \(key)")
+            throw ErrorHandlingDomains.UmbraErrors.Security.Protocols.makeStorageOperationFailed(message: "No data found for key: \(key)")
         }
         return (data, metadata[key])
     }
 
     public func delete(forKey key: String) async throws {
         guard storage.removeValue(forKey: key) != nil else {
-            throw SecurityInterfaces.SecurityError.operationFailed("No data found for key: \(key)")
+            throw ErrorHandlingDomains.UmbraErrors.Security.Protocols.makeStorageOperationFailed(message: "No data found for key: \(key)")
         }
         metadata.removeValue(forKey: key)
     }
 
     public func getMetadata(forKey key: String) async throws -> [String: String]? {
         guard storage[key] != nil else {
-            throw SecurityInterfaces.SecurityError.operationFailed("No data found for key: \(key)")
+            throw ErrorHandlingDomains.UmbraErrors.Security.Protocols.makeStorageOperationFailed(message: "No data found for key: \(key)")
         }
         return metadata[key]
     }
 
     public func updateMetadata(_ metadata: [String: String], forKey key: String) async throws {
         guard storage[key] != nil else {
-            throw SecurityInterfaces.SecurityError.operationFailed("No data found for key: \(key)")
+            throw ErrorHandlingDomains.UmbraErrors.Security.Protocols.makeStorageOperationFailed(message: "No data found for key: \(key)")
         }
         self.metadata[key] = metadata
     }

--- a/Tests/UmbraTestKit/Tests/SecurityErrorHandlerTests.swift
+++ b/Tests/UmbraTestKit/Tests/SecurityErrorHandlerTests.swift
@@ -18,7 +18,7 @@ public class SecurityErrorHandler {
 
     public init() {}
 
-    public func handleError(_ error: SecurityInterfaces.SecurityError, context: String) -> Bool {
+    public func handleError(_ error: ErrorHandlingDomains.UmbraErrors.Security.Protocols, context: String) -> Bool {
         let key = "\(context):\(error)"
         let currentCount = errorCounts[key] ?? 0
         errorCounts[key] = currentCount + 1
@@ -75,7 +75,7 @@ final class SecurityErrorHandlerTests: XCTestCase {
 
     func testHandleRetryableError() async throws {
         let shouldRetry = handler.handleError(
-            SecurityInterfaces.SecurityError.accessError("Permission denied"),
+            ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Permission denied"),
             context: "test"
         )
         XCTAssertTrue(shouldRetry, "First occurrence of retryable error should allow retry")
@@ -84,25 +84,25 @@ final class SecurityErrorHandlerTests: XCTestCase {
     func testMaxRetries() async throws {
         // First attempt
         _ = handler.handleError(
-            SecurityInterfaces.SecurityError.accessError("Permission denied"),
+            ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Permission denied"),
             context: "test"
         )
 
         // Second attempt
         _ = handler.handleError(
-            SecurityInterfaces.SecurityError.accessError("Permission denied"),
+            ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Permission denied"),
             context: "test"
         )
 
         // Third attempt
         _ = handler.handleError(
-            SecurityInterfaces.SecurityError.accessError("Permission denied"),
+            ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Permission denied"),
             context: "test"
         )
 
         // Fourth attempt should not retry
         let shouldRetry = handler.handleError(
-            SecurityInterfaces.SecurityError.accessError("Permission denied"),
+            ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Permission denied"),
             context: "test"
         )
         XCTAssertFalse(shouldRetry, "Should not retry after max retries")
@@ -110,11 +110,11 @@ final class SecurityErrorHandlerTests: XCTestCase {
 
     func testErrorStatsTracking() async throws {
         _ = handler.handleError(
-            SecurityInterfaces.SecurityError.accessError("Test error"),
+            ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Test error"),
             context: "test1"
         )
         _ = handler.handleError(
-            SecurityInterfaces.SecurityError.accessError("Test error"),
+            ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Test error"),
             context: "test2"
         )
 
@@ -137,7 +137,7 @@ final class SecurityErrorHandlerTests: XCTestCase {
 
         // Mark an error for test_context
         _ = testHandler.handleError(
-            SecurityInterfaces.SecurityError.accessError("Test error"),
+            ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Test error"),
             context: "test_context"
         )
 
@@ -147,7 +147,7 @@ final class SecurityErrorHandlerTests: XCTestCase {
 
     func testContextReset() async throws {
         _ = handler.handleError(
-            SecurityInterfaces.SecurityError.accessError("Test error"),
+            ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Test error"),
             context: "test"
         )
 
@@ -156,7 +156,7 @@ final class SecurityErrorHandlerTests: XCTestCase {
 
         // After reset, should be able to retry
         let shouldRetry = handler.handleError(
-            SecurityInterfaces.SecurityError.accessError("Test error"),
+            ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Test error"),
             context: "test"
         )
         XCTAssertTrue(shouldRetry)

--- a/Tests/UmbraTestKit/Tests/SecurityErrorTests.swift
+++ b/Tests/UmbraTestKit/Tests/SecurityErrorTests.swift
@@ -12,24 +12,24 @@ final class SecurityErrorTests: XCTestCase {
     ]
 
     func testErrorDescription() {
-        let error = SecurityInterfaces.SecurityError.accessError("Access denied to /test/path")
+        let error = ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Access denied to /test/path")
         XCTAssertEqual(
             error.errorDescription,
-            "Security access error: Access denied to /test/path"
+            "Service error: Access denied to /test/path"
         )
     }
 
     func testErrorEquality() {
-        let error1 = SecurityInterfaces.SecurityError.accessError("Access denied to /test/path")
-        let error2 = SecurityInterfaces.SecurityError.accessError("Access denied to /test/path")
-        let error3 = SecurityInterfaces.SecurityError.accessError("Access denied to /different/path")
+        let error1 = ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Access denied to /test/path")
+        let error2 = ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Access denied to /test/path")
+        let error3 = ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Access denied to /different/path")
 
         XCTAssertEqual(error1.errorDescription, error2.errorDescription)
         XCTAssertNotEqual(error1.errorDescription, error3.errorDescription)
     }
 
     func testErrorMetadata() {
-        let error = SecurityInterfaces.SecurityError.accessError("Access denied to /test/path")
-        XCTAssertEqual(error.errorDescription, "Security access error: Access denied to /test/path")
+        let error = ErrorHandlingDomains.UmbraErrors.Security.Protocols.serviceError("Access denied to /test/path")
+        XCTAssertEqual(error.errorDescription, "Service error: Access denied to /test/path")
     }
 }

--- a/build_errors_summary.md
+++ b/build_errors_summary.md
@@ -137,6 +137,18 @@ This analysis aligns with the ongoing XPC Protocol Consolidation and Foundation-
    - Updated references to security-related types
    - Ensured UmbraSecurity module builds successfully
 
+3. **✅ COMPLETED: Test Mock Implementations (21 March 2025)**
+   - Updated TestMockSecurityProvider to use Foundation-independent types
+   - Fixed MockCryptoService to fully implement CryptoServiceProtocol
+   - Ensured all tests in UmbraTestKitTests pass successfully
+   - Replaced all references to CoreTypesInterfaces.Data with appropriate Foundation-independent alternatives
+   - Fixed error handling to use ErrorHandlingDomains.UmbraErrors.Security.Protocols
+
+4. **✅ COMPLETED: Core Module ServiceState References (21 March 2025)**
+   - Fixed unqualified ServiceState references in CryptoService.swift
+   - Updated to use fully qualified CoreServicesTypes.ServiceState
+   - Resolved "cannot infer contextual base" compiler errors
+
 ## Current Build Status
 
 As of 21 March 2025, the following key modules now build successfully:


### PR DESCRIPTION
- Update TestMockSecurityProvider to use Foundation-independent types
- Implement missing methods in MockCryptoService to conform to protocol
- Replace references to CoreTypesInterfaces.Data with type-safe alternatives
- Properly qualify ServiceState references in CryptoService
- Fix error handling to use UmbraErrors.Security.Protocols consistently
- Update build_errors_summary.md with progress tracking

Part of the ongoing effort to eliminate Foundation dependencies and standardise error handling throughout the codebase.