### PR TITLE
Fix YAML syntax in GitHub Actions workflows

### DIFF
--- a/.github/workflows/docc-build.yml
+++ b/.github/workflows/docc-build.yml
@@ -5,16 +5,16 @@ on:
     branches:
       - main
     paths:
-      - **.swift
-      - docc_config.yml
-      - .github/workflows/docc-build.yml
+      - '**.swift'
+      - 'docc_config.yml'
+      - '.github/workflows/docc-build.yml'
   pull_request:
     branches:
       - main
     paths:
-      - **.swift
-      - docc_config.yml
-      - .github/workflows/docc-build.yml
+      - '**.swift'
+      - 'docc_config.yml'
+      - '.github/workflows/docc-build.yml'
   workflow_dispatch:
 
 


### PR DESCRIPTION
## Changes
- Fix YAML syntax errors in workflow files by properly quoting wildcard patterns
- Rebuild all workflows with consistent naming conventions
- Ensure all workflows use the self-hosted runner
- Validate all workflow YAML files for correctness

This PR builds upon the workflow changes merged in #58 and fixes some syntax errors in the generated YAML files.