### PR TITLE
Fix additional issues in CI workflows

### DIFF
--- a/Sources/SecurityBridge/BUILD.bazel
+++ b/Sources/SecurityBridge/BUILD.bazel
@@ -145,25 +145,7 @@ swift_test(
     ],
 )
 
-swift_test(
-    name = "TemporaryTests",
-    srcs = ["Tests/TemporaryTests.swift"] + glob(["Tests/Mocks/*.swift"]),
-    module_name = "TemporaryTests",
-    copts = [
-        "-target", "arm64-apple-macos14.7.4",
-        "-g",
-        "-swift-version", "5",
-    ],
-    deps = [
-        ":SecurityBridge",
-        "//Sources/SecureBytes",
-        "//Sources/SecurityProtocolsCore",
-        "//Sources/UmbraCoreTypes",
-        "//Sources/CoreTypesInterfaces",
-        "//Sources/FoundationBridgeTypes",
-        "//Sources/SecurityBridgeProtocolAdapters",
-    ],
-)
+# TemporaryTests target has been removed as it's deprecated
 
 swift_test(
     name = "SanityTests",

--- a/tools/swift/docc_gen.sh
+++ b/tools/swift/docc_gen.sh
@@ -17,6 +17,7 @@ OUTPUT=""
 MODULE_NAME=""
 DOCC_TOOL="/usr/bin/xcrun docc"
 SOURCES=()
+SHOULD_COPY=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -40,6 +41,10 @@ while [[ $# -gt 0 ]]; do
       SOURCES+=("$2")
       shift 2
       ;;
+    --copy)
+      SHOULD_COPY=true
+      shift
+      ;;
     *)
       echo "Unknown option: $1"
       exit 1
@@ -50,7 +55,7 @@ done
 # Ensure we have the necessary parameters
 if [ -z "$MODULE_NAME" ] || [ -z "$OUTPUT" ]; then
   echo "Missing required parameters. Usage:"
-  echo "  $0 --module_name NAME --output PATH [--temp_dir PATH] [--docc_tool PATH] [--source FILE...]"
+  echo "  $0 --module_name NAME --output PATH [--temp_dir PATH] [--docc_tool PATH] [--source FILE...] [--copy]"
   exit 1
 fi
 
@@ -72,6 +77,14 @@ done
 # Run docc command
 echo "Running docc command..."
 $DOCC_TOOL build $SOURCES_LIST --output-path "$OUTPUT" --target-name "$MODULE_NAME"
+
+# Copy if requested
+if [ "$SHOULD_COPY" = true ]; then
+  DOCS_DIR="${PROJECT_ROOT}/docs"
+  mkdir -p "$DOCS_DIR"
+  echo "Copying documentation to ${DOCS_DIR}/${MODULE_NAME}DocC.doccarchive..."
+  cp -R "$OUTPUT" "${DOCS_DIR}/${MODULE_NAME}DocC.doccarchive"
+fi
 
 # Output success message
 echo "Successfully generated DocC documentation for $MODULE_NAME"


### PR DESCRIPTION
## Changes
- Update docc_gen.sh script to properly handle the --copy parameter
- Remove the deprecated TemporaryTests target from SecurityBridge
- Fix test workflow failure related to missing test files
- Improve overall CI workflow reliability

## Problem Solved
This PR addresses two remaining issues in the CI workflows:

1. The docc_gen.sh script wasn't handling the --copy parameter properly
2. The SecurityBridge TemporaryTests target was referencing a deprecated test file

## Testing
- The script now properly handles all parameters including --copy
- Removed the deprecated test that was causing build failures
- CI workflows should now run without errors