### PR TITLE
refactor(Security): Consolidate Core protocols and fix circular dependencies

### DIFF
--- a/Sources/Security/Adapters/Foundation/BUILD.bazel
+++ b/Sources/Security/Adapters/Foundation/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//bazel:swift_rules.bzl", "umbra_swift_library")
+
+# Foundation adapters for Security services
+# Provides integration with Foundation framework components
+umbra_swift_library(
+    name = "Foundation",
+    srcs = glob(
+        ["**/*.swift"],
+        exclude = ["**/*.generated.swift"],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//Sources/Security/Core/Protocols",
+        "//Sources/Security/Core/Types",
+        "//Sources/UmbraCoreTypes",
+    ],
+)

--- a/Sources/Security/BUILD.bazel
+++ b/Sources/Security/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//bazel:swift_rules.bzl", "umbra_swift_library")
+
+# Top-level package for consolidated Security functionality
+umbra_swift_library(
+    name = "Security",
+    srcs = glob(["*.swift"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//Sources/Security/Core/Protocols",
+        "//Sources/Security/Core/Types",
+        "//Sources/Security/Core/Errors",
+        "//Sources/Security/Implementation/Crypto",
+        "//Sources/Security/Adapters/Foundation",
+        "//Sources/Security/Utils",
+    ],
+)

--- a/Sources/Security/Core/Errors/BUILD.bazel
+++ b/Sources/Security/Core/Errors/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//bazel:swift_rules.bzl", "umbra_swift_library")
+
+# Core security errors
+# This module contains foundational security error definitions
+umbra_swift_library(
+    name = "Errors",
+    srcs = glob(
+        ["**/*.swift"],
+        exclude = ["**/*.generated.swift"],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//Sources/CoreErrors",
+    ],
+)

--- a/Sources/Security/Core/Errors/SecurityError.swift
+++ b/Sources/Security/Core/Errors/SecurityError.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Security error implementation
+/// Represents errors specific to security operations with descriptive messages
+public struct SecurityError: Error, Equatable, Sendable {
+  /// Error description
+  public let description: String
+
+  /// Initialise with a description
+  public init(description: String) {
+    self.description = description
+  }
+
+  /// Compare two SecurityErrors
+  public static func == (lhs: SecurityError, rhs: SecurityError) -> Bool {
+    lhs.description == rhs.description
+  }
+
+  /// Create with a reason
+  public static func withReason(_ reason: String) -> SecurityError {
+    SecurityError(description: reason)
+  }
+}
+
+/// Error domain namespace
+/// Provides standardised domain strings for error categorisation
+public enum SecurityErrorDomain {
+  /// Security domain
+  public static let security = "Security"
+  /// Crypto domain
+  public static let crypto = "Crypto"
+  /// Key management domain
+  public static let keyManagement = "KeyManagement"
+  /// Storage domain
+  public static let storage = "Storage"
+  /// XPC service domain
+  public static let xpcService = "XPCService"
+  /// General application domain
+  public static let application = "Application"
+}

--- a/Sources/Security/Core/Errors/SecurityProtocolError.swift
+++ b/Sources/Security/Core/Errors/SecurityProtocolError.swift
@@ -1,0 +1,83 @@
+import Foundation
+import UmbraCoreTypes
+
+/// Error type specifically for security protocol operations
+/// Used throughout the security protocol interfaces for consistent error handling
+public enum SecurityProtocolError: Error, Equatable, Sendable {
+  /// Operation failed due to an internal error
+  case internalError(String)
+  
+  /// Invalid input was provided
+  case invalidInput(String)
+  
+  /// Operation is not supported by the implementation
+  case unsupportedOperation(name: String)
+  
+  /// Key management error occurred
+  case keyManagementError(String)
+  
+  /// Cryptographic operation failed
+  case cryptographicError(String)
+  
+  /// Authentication failed
+  case authenticationFailed(String)
+  
+  /// Secure storage operation failed
+  case storageError(String)
+  
+  /// Security configuration error
+  case configurationError(String)
+  
+  /// General security error with explanation
+  case securityError(String)
+  
+  /// Error comparison
+  public static func == (lhs: SecurityProtocolError, rhs: SecurityProtocolError) -> Bool {
+    switch (lhs, rhs) {
+    case let (.internalError(lmsg), .internalError(rmsg)):
+      return lmsg == rmsg
+    case let (.invalidInput(lmsg), .invalidInput(rmsg)):
+      return lmsg == rmsg
+    case let (.unsupportedOperation(lname), .unsupportedOperation(rname)):
+      return lname == rname
+    case let (.keyManagementError(lmsg), .keyManagementError(rmsg)):
+      return lmsg == rmsg
+    case let (.cryptographicError(lmsg), .cryptographicError(rmsg)):
+      return lmsg == rmsg
+    case let (.authenticationFailed(lmsg), .authenticationFailed(rmsg)):
+      return lmsg == rmsg
+    case let (.storageError(lmsg), .storageError(rmsg)):
+      return lmsg == rmsg
+    case let (.configurationError(lmsg), .configurationError(rmsg)):
+      return lmsg == rmsg
+    case let (.securityError(lmsg), .securityError(rmsg)):
+      return lmsg == rmsg
+    default:
+      return false
+    }
+  }
+  
+  /// Maps this error to a descriptive message
+  public var localizedDescription: String {
+    switch self {
+    case .internalError(let message):
+      return "Internal error: \(message)"
+    case .invalidInput(let message):
+      return "Invalid input: \(message)"
+    case .unsupportedOperation(let name):
+      return "Unsupported operation: \(name)"
+    case .keyManagementError(let message):
+      return "Key management error: \(message)"
+    case .cryptographicError(let message):
+      return "Cryptographic error: \(message)"
+    case .authenticationFailed(let message):
+      return "Authentication failed: \(message)"
+    case .storageError(let message):
+      return "Storage error: \(message)"
+    case .configurationError(let message):
+      return "Configuration error: \(message)"
+    case .securityError(let message):
+      return "Security error: \(message)"
+    }
+  }
+}

--- a/Sources/Security/Core/Protocols/BUILD.bazel
+++ b/Sources/Security/Core/Protocols/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//bazel:swift_rules.bzl", "umbra_swift_library")
+
+# Core security protocols
+# This module contains foundational security protocol definitions
+# that other modules can implement or extend
+umbra_swift_library(
+    name = "Protocols",
+    srcs = glob(
+        ["**/*.swift"],
+        exclude = ["**/*.generated.swift"],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//Sources/Security/Core/Errors:Errors",
+        "//Sources/Security/Core/Types:Types",
+        "//Sources/UmbraCoreTypes/Sources:UmbraCoreTypes",
+        "//Sources/UmbraErrors",
+    ],
+)

--- a/Sources/Security/Core/Protocols/CryptoServiceProtocol.swift
+++ b/Sources/Security/Core/Protocols/CryptoServiceProtocol.swift
@@ -1,0 +1,73 @@
+import UmbraCoreTypes
+import Errors
+import Types
+
+/// Protocol defining cryptographic service operations in a FoundationIndependent manner.
+/// All operations use only primitive types and FoundationIndependent custom types.
+public protocol CryptoServiceProtocol: Sendable {
+  /// Encrypts binary data using the provided key.
+  /// - Parameters:
+  ///   - data: Data to encrypt as `SecureBytes`.
+  ///   - key: Encryption key as `SecureBytes`.
+  /// - Returns: The encrypted data as `SecureBytes` or an error.
+  func encrypt(data: SecureBytes, using key: SecureBytes) async
+    -> Result<SecureBytes, SecurityProtocolError>
+
+  /// Decrypts binary data using the provided key.
+  /// - Parameters:
+  ///   - data: Data to decrypt as `SecureBytes`.
+  ///   - key: Decryption key as `SecureBytes`.
+  /// - Returns: The decrypted data as `SecureBytes` or an error.
+  func decrypt(data: SecureBytes, using key: SecureBytes) async
+    -> Result<SecureBytes, SecurityProtocolError>
+
+  /// Generates a random cryptographic key.
+  /// - Parameter size: Size of the key in bytes.
+  /// - Returns: The generated key as `SecureBytes` or an error.
+  func generateKey(size: Int) async -> Result<SecureBytes, SecurityProtocolError>
+
+  /// Calculates a cryptographic hash of data.
+  /// - Parameter data: Data to hash as `SecureBytes`.
+  /// - Returns: The hash value as `SecureBytes` or an error.
+  func hash(data: SecureBytes) async -> Result<SecureBytes, SecurityProtocolError>
+
+  /// Verifies that data matches a hash.
+  /// - Parameters:
+  ///   - data: Data to verify as `SecureBytes`.
+  ///   - hash: Hash to check against as `SecureBytes`.
+  /// - Returns: Boolean indicating if verification passed or an error.
+  func verifyHash(data: SecureBytes, against hash: SecureBytes) async
+    -> Result<Bool, SecurityProtocolError>
+
+  /// Generates secure random bytes.
+  /// - Parameter length: Number of bytes to generate.
+  /// - Returns: Random bytes as `SecureBytes` or an error.
+  func generateRandomBytes(length: Int) async
+    -> Result<SecureBytes, SecurityProtocolError>
+
+  // MARK: - Symmetric Encryption
+
+  /// Encrypts data using authenticated encryption with associated data (AEAD).
+  /// - Parameters:
+  ///   - data: Data to encrypt as `SecureBytes`.
+  ///   - key: Encryption key as `SecureBytes`.
+  ///   - config: Encryption configuration.
+  /// - Returns: Encrypted data as `SecureBytes` or an error.
+  func encryptWithConfiguration(
+    data: SecureBytes,
+    key: SecureBytes,
+    config: SecurityConfigDTO
+  ) async -> Result<SecureBytes, SecurityProtocolError>
+
+  /// Decrypts data using authenticated encryption with associated data (AEAD).
+  /// - Parameters:
+  ///   - data: Data to decrypt as `SecureBytes`.
+  ///   - key: Decryption key as `SecureBytes`.
+  ///   - config: Decryption configuration.
+  /// - Returns: Decrypted data as `SecureBytes` or an error.
+  func decryptWithConfiguration(
+    data: SecureBytes,
+    key: SecureBytes,
+    config: SecurityConfigDTO
+  ) async -> Result<SecureBytes, SecurityProtocolError>
+}

--- a/Sources/Security/Core/Protocols/KeyManagementProtocol.swift
+++ b/Sources/Security/Core/Protocols/KeyManagementProtocol.swift
@@ -1,0 +1,43 @@
+import UmbraCoreTypes
+import Errors
+
+/// Protocol defining secure key management operations in a FoundationIndependent manner.
+/// All operations use only primitive types and FoundationIndependent custom types.
+public protocol KeyManagementProtocol: Sendable {
+  /// Retrieves a security key by its identifier.
+  /// - Parameter identifier: A string identifying the key.
+  /// - Returns: The security key as `SecureBytes` or an error.
+  func retrieveKey(withIdentifier identifier: String) async
+    -> Result<SecureBytes, SecurityProtocolError>
+
+  /// Stores a security key with the given identifier.
+  /// - Parameters:
+  ///   - key: The security key as `SecureBytes`.
+  ///   - identifier: A string identifier for the key.
+  /// - Returns: Success or an error.
+  func storeKey(_ key: SecureBytes, withIdentifier identifier: String) async
+    -> Result<Void, SecurityProtocolError>
+
+  /// Deletes a security key with the given identifier.
+  /// - Parameter identifier: A string identifying the key to delete.
+  /// - Returns: Success or an error.
+  func deleteKey(withIdentifier identifier: String) async
+    -> Result<Void, SecurityProtocolError>
+
+  /// Rotates a security key, creating a new key and optionally re-encrypting data.
+  /// - Parameters:
+  ///   - identifier: A string identifying the key to rotate.
+  ///   - dataToReencrypt: Optional data to re-encrypt with the new key.
+  /// - Returns: The new key and re-encrypted data (if provided) or an error.
+  func rotateKey(
+    withIdentifier identifier: String,
+    dataToReencrypt: SecureBytes?
+  ) async -> Result<(
+    newKey: SecureBytes,
+    reencryptedData: SecureBytes?
+  ), SecurityProtocolError>
+
+  /// Lists all available key identifiers.
+  /// - Returns: An array of key identifiers or an error.
+  func listKeyIdentifiers() async -> Result<[String], SecurityProtocolError>
+}

--- a/Sources/Security/Core/Protocols/SecureStorageProtocol.swift
+++ b/Sources/Security/Core/Protocols/SecureStorageProtocol.swift
@@ -1,0 +1,30 @@
+import UmbraCoreTypes
+import Errors
+
+/// Protocol defining secure storage operations in a FoundationIndependent manner.
+/// All operations use only primitive types and FoundationIndependent custom types.
+public protocol SecureStorageProtocol: Sendable {
+  /// Stores data securely with the given identifier.
+  /// - Parameters:
+  ///   - data: The data to store as `SecureBytes`.
+  ///   - identifier: A string identifier for the stored data.
+  /// - Returns: Success or an error.
+  func storeData(_ data: SecureBytes, withIdentifier identifier: String) async
+    -> Result<Void, SecurityProtocolError>
+
+  /// Retrieves data securely by its identifier.
+  /// - Parameter identifier: A string identifying the data to retrieve.
+  /// - Returns: The retrieved data as `SecureBytes` or an error.
+  func retrieveData(withIdentifier identifier: String) async
+    -> Result<SecureBytes, SecurityProtocolError>
+
+  /// Deletes data securely by its identifier.
+  /// - Parameter identifier: A string identifying the data to delete.
+  /// - Returns: Success or an error.
+  func deleteData(withIdentifier identifier: String) async
+    -> Result<Void, SecurityProtocolError>
+
+  /// Lists all available data identifiers.
+  /// - Returns: An array of data identifiers or an error.
+  func listDataIdentifiers() async -> Result<[String], SecurityProtocolError>
+}

--- a/Sources/Security/Core/Protocols/SecurityProviderBase.swift
+++ b/Sources/Security/Core/Protocols/SecurityProviderBase.swift
@@ -1,0 +1,63 @@
+import UmbraErrors
+import UmbraCoreTypes
+import Errors
+
+/// Base protocol for security providers
+/// This protocol is designed to be Foundation-free and serve as a base for more specific security
+/// provider protocols
+public protocol SecurityProviderBase: Sendable {
+  /// Protocol identifier - used for protocol negotiation
+  static var protocolIdentifier: String { get }
+
+  /// Test if the security provider is available
+  /// - Returns: True if the provider is available, false otherwise
+  /// - Throws: UmbraErrors.Security.Protocols if the check fails
+  func isAvailable() async throws -> Bool
+
+  /// Get the provider's version information
+  /// - Returns: Version string
+  func getVersion() async -> String
+}
+
+/// Default implementation for SecurityProviderBase
+extension SecurityProviderBase {
+  /// Default protocol identifier
+  public static var protocolIdentifier: String {
+    "com.umbra.security.provider.base"
+  }
+
+  /// Default implementation that assumes the provider is available
+  public func isAvailable() async throws -> Bool {
+    true
+  }
+
+  /// Default version string
+  public func getVersion() async -> String {
+    "1.0.0"
+  }
+}
+
+/// Adapter class to convert between SecurityProviderProtocol and SecurityProviderBase
+public final class SecurityProviderBaseAdapter: SecurityProviderBase {
+  private let provider: any SecurityProviderProtocol
+
+  public init(provider: any SecurityProviderProtocol) {
+    self.provider = provider
+  }
+
+  public static var protocolIdentifier: String {
+    "com.umbra.security.provider.base.adapter"
+  }
+
+  public func isAvailable() async throws -> Bool {
+    // This is a simple implementation that assumes the provider is available
+    // In a real implementation, you might want to perform some checks
+    true
+  }
+
+  public func getVersion() async -> String {
+    // This is a simple implementation that returns a fixed version
+    // In a real implementation, you might want to get the version from the provider
+    "1.0.0"
+  }
+}

--- a/Sources/Security/Core/Protocols/SecurityProviderProtocol.swift
+++ b/Sources/Security/Core/Protocols/SecurityProviderProtocol.swift
@@ -1,0 +1,33 @@
+import UmbraCoreTypes
+import Types
+import Errors
+
+/// Top-level protocol defining a complete security provider in a FoundationIndependent manner.
+/// This protocol consolidates cryptographic operations, key management, and security configuration
+/// into a cohesive interface for secure operations.
+public protocol SecurityProviderProtocol: Sendable {
+  // MARK: - Service Access
+
+  /// Access to cryptographic service implementation
+  var cryptoService: CryptoServiceProtocol { get }
+
+  /// Access to key management service implementation
+  var keyManager: KeyManagementProtocol { get }
+
+  // MARK: - Convenience Methods
+
+  /// Perform a secure operation with appropriate error handling
+  /// - Parameters:
+  ///   - operation: The security operation to perform
+  ///   - config: Configuration options
+  /// - Returns: Result of the operation
+  func performSecureOperation(
+    operation: SecurityOperation,
+    config: SecurityConfigDTO
+  ) async -> SecurityResultDTO
+
+  /// Create a secure configuration with appropriate defaults
+  /// - Parameter options: Optional dictionary of configuration options
+  /// - Returns: A properly configured SecurityConfigDTO
+  func createSecureConfig(options: [String: Any]?) -> SecurityConfigDTO
+}

--- a/Sources/Security/Core/Protocols/XPCServiceProtocolCore.swift
+++ b/Sources/Security/Core/Protocols/XPCServiceProtocolCore.swift
@@ -1,0 +1,84 @@
+import UmbraCoreTypes
+import Errors
+
+/// Protocol defining core XPC service functionality without Foundation dependencies.
+/// This protocol uses SecureBytes for binary data to avoid custom type definitions
+/// and ensure compatibility with the rest of the security architecture.
+public protocol XPCServiceProtocolCore: Sendable {
+  /// Protocol identifier used for service discovery and protocol negotiation
+  static var protocolIdentifier: String { get }
+
+  /// Test connectivity with the XPC service
+  /// - Returns: Boolean indicating whether the service is responsive
+  func ping() async -> Result<Bool, SecurityProtocolError>
+
+  /// Synchronise encryption keys across processes
+  /// - Parameter syncData: Key synchronisation data
+  /// - Returns: Success or a descriptive error
+  func synchronizeKeys(_ syncData: SecureBytes) async
+    -> Result<Void, SecurityProtocolError>
+
+  /// Encrypt data using a service-managed key
+  /// - Parameter data: Data to encrypt
+  /// - Returns: Encrypted data or an error
+  func encrypt(data: SecureBytes) async
+    -> Result<SecureBytes, SecurityProtocolError>
+
+  /// Decrypt data using a service-managed key
+  /// - Parameter data: Data to decrypt
+  /// - Returns: Decrypted data or an error
+  func decrypt(data: SecureBytes) async
+    -> Result<SecureBytes, SecurityProtocolError>
+
+  /// Generate a new cryptographic key
+  /// - Returns: Generated key or an error
+  func generateKey() async -> Result<SecureBytes, SecurityProtocolError>
+
+  /// Compute a cryptographic hash of data
+  /// - Parameter data: Data to hash
+  /// - Returns: Hash value or an error
+  func hash(data: SecureBytes) async
+    -> Result<SecureBytes, SecurityProtocolError>
+}
+
+/// Default implementations for XPCServiceProtocolCore functions
+extension XPCServiceProtocolCore {
+  /// Default protocol identifier
+  public static var protocolIdentifier: String {
+    "com.umbra.xpc.service.protocol.core"
+  }
+
+  /// Default implementation that returns a ping success
+  public func ping() async -> Result<Bool, SecurityProtocolError> {
+    .success(true)
+  }
+
+  /// Default implementation that returns a not implemented error
+  public func synchronizeKeys(_: SecureBytes) async
+  -> Result<Void, SecurityProtocolError> {
+    .failure(.unsupportedOperation(name: "synchronizeKeys"))
+  }
+
+  /// Default implementation that returns a not implemented error
+  public func encrypt(data _: SecureBytes) async
+  -> Result<SecureBytes, SecurityProtocolError> {
+    .failure(.unsupportedOperation(name: "encrypt"))
+  }
+
+  /// Default implementation that returns a not implemented error
+  public func decrypt(data _: SecureBytes) async
+  -> Result<SecureBytes, SecurityProtocolError> {
+    .failure(.unsupportedOperation(name: "decrypt"))
+  }
+
+  /// Default implementation that returns a not implemented error
+  public func generateKey() async -> Result<SecureBytes, SecurityProtocolError> {
+    .failure(.unsupportedOperation(name: "generateKey"))
+  }
+
+  /// Default implementation that returns a not implemented error
+  public func hash(data _: SecureBytes) async
+  -> Result<SecureBytes, SecurityProtocolError> {
+    .failure(.unsupportedOperation(name: "hash"))
+  }
+}

--- a/Sources/Security/Core/Types/BUILD.bazel
+++ b/Sources/Security/Core/Types/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//bazel:swift_rules.bzl", "umbra_swift_library")
+
+# Core security types
+# This module contains foundational security type definitions
+umbra_swift_library(
+    name = "Types",
+    srcs = glob(
+        ["**/*.swift"],
+        exclude = ["**/*.generated.swift"],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//Sources/UmbraCoreTypes/Sources:UmbraCoreTypes",
+    ],
+)

--- a/Sources/Security/Core/Types/HashAlgorithm.swift
+++ b/Sources/Security/Core/Types/HashAlgorithm.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Hash algorithm options for cryptographic hashing
+/// Defines standard hash algorithms used across the security framework
+public enum HashAlgorithm: String, Sendable, CaseIterable {
+  /// SHA-256 hash algorithm (256 bits)
+  case sha256 = "SHA256"
+
+  /// SHA-384 hash algorithm (384 bits)
+  case sha384 = "SHA384"
+
+  /// SHA-512 hash algorithm (512 bits)
+  case sha512 = "SHA512"
+
+  /// The length of the digest in bytes
+  public var digestLength: Int {
+    switch self {
+      case .sha256:
+        return 32  // 256 bits = 32 bytes
+      case .sha384:
+        return 48  // 384 bits = 48 bytes
+      case .sha512:
+        return 64  // 512 bits = 64 bytes
+    }
+  }
+  
+  /// Standard algorithm identifier string
+  public var algorithmIdentifier: String {
+    self.rawValue
+  }
+  
+  /// Returns the algorithm identifier suitable for the platform's native crypto libraries
+  public var platformIdentifier: Int {
+    switch self {
+      case .sha256:
+        return 6  // Corresponds to kCCHmacAlgSHA256 on Apple platforms
+      case .sha384:
+        return 8  // Custom value for SHA384
+      case .sha512:
+        return 7  // Corresponds to kCCHmacAlgSHA512 on Apple platforms
+    }
+  }
+}

--- a/Sources/Security/Core/Types/SecurityConfigDTO.swift
+++ b/Sources/Security/Core/Types/SecurityConfigDTO.swift
@@ -1,0 +1,82 @@
+import Foundation
+import UmbraCoreTypes
+
+/// Security configuration data transfer object
+/// Used to configure security operations with specific options
+public struct SecurityConfigDTO: Sendable, Equatable {
+  /// Algorithm to use for cryptographic operations
+  public enum Algorithm: String, Sendable, Equatable {
+    /// AES algorithm
+    case aes = "AES"
+    /// RSA algorithm
+    case rsa = "RSA"
+    /// ChaCha20 algorithm
+    case chacha20 = "ChaCha20"
+  }
+  
+  /// Mode of operation for block ciphers
+  public enum Mode: String, Sendable, Equatable {
+    /// Galois/Counter Mode
+    case gcm = "GCM"
+    /// Cipher Block Chaining
+    case cbc = "CBC"
+    /// Counter Mode
+    case ctr = "CTR"
+  }
+  
+  /// Key size in bits
+  public let keySize: Int
+  
+  /// Algorithm to use
+  public let algorithm: Algorithm
+  
+  /// Mode of operation (for block ciphers)
+  public let mode: Mode?
+  
+  /// Hash algorithm for hashing operations
+  public let hashAlgorithm: HashAlgorithm
+  
+  /// Authentication data (for authenticated encryption modes)
+  public let authenticationData: SecureBytes?
+  
+  /// Additional options as key-value pairs
+  public let options: [String: String]
+  
+  /// Initialise with configuration options
+  /// - Parameters:
+  ///   - keySize: Key size in bits (default: 256)
+  ///   - algorithm: Algorithm to use (default: .aes)
+  ///   - mode: Mode of operation (default: .gcm)
+  ///   - hashAlgorithm: Hash algorithm (default: .sha256)
+  ///   - authenticationData: Authentication data (default: nil)
+  ///   - options: Additional options (default: empty dictionary)
+  public init(
+    keySize: Int = 256,
+    algorithm: Algorithm = .aes,
+    mode: Mode? = .gcm,
+    hashAlgorithm: HashAlgorithm = .sha256,
+    authenticationData: SecureBytes? = nil,
+    options: [String: String] = [:]
+  ) {
+    self.keySize = keySize
+    self.algorithm = algorithm
+    self.mode = mode
+    self.hashAlgorithm = hashAlgorithm
+    self.authenticationData = authenticationData
+    self.options = options
+  }
+  
+  /// Create a copy with modified options
+  /// - Parameter options: New options to apply
+  /// - Returns: A new configuration with updated options
+  public func withOptions(_ options: [String: String]) -> SecurityConfigDTO {
+    SecurityConfigDTO(
+      keySize: self.keySize,
+      algorithm: self.algorithm,
+      mode: self.mode,
+      hashAlgorithm: self.hashAlgorithm,
+      authenticationData: self.authenticationData,
+      options: options
+    )
+  }
+}

--- a/Sources/Security/Core/Types/SecurityOperation.swift
+++ b/Sources/Security/Core/Types/SecurityOperation.swift
@@ -1,0 +1,68 @@
+import Foundation
+import UmbraCoreTypes
+
+/// Defines security operations that can be performed by the security provider
+/// This type allows for a unified interface for different security operations
+public enum SecurityOperation: Sendable, Equatable {
+  /// Encrypt data using the specified parameters
+  case encrypt(data: SecureBytes, key: SecureBytes?)
+  
+  /// Decrypt data using the specified parameters
+  case decrypt(data: SecureBytes, key: SecureBytes?)
+  
+  /// Generate a secure cryptographic key
+  case generateKey(size: Int?)
+  
+  /// Compute a cryptographic hash
+  case hash(data: SecureBytes, algorithm: HashAlgorithm?)
+  
+  /// Sign data using a private key
+  case sign(data: SecureBytes, key: SecureBytes?)
+  
+  /// Verify a signature using a public key
+  case verify(data: SecureBytes, signature: SecureBytes, key: SecureBytes?)
+  
+  /// Derive a key from a password or other input
+  case deriveKey(input: SecureBytes, salt: SecureBytes?)
+  
+  /// Securely store data
+  case store(data: SecureBytes, identifier: String)
+  
+  /// Retrieve securely stored data
+  case retrieve(identifier: String)
+  
+  /// Delete securely stored data
+  case delete(identifier: String)
+  
+  /// Custom operation with parameters
+  case custom(operationName: String, parameters: [String: SecureBytes])
+  
+  /// Returns a string representation of the operation type
+  /// suitable for logging and debugging (without sensitive data)
+  public var operationType: String {
+    switch self {
+    case .encrypt:
+      return "encrypt"
+    case .decrypt:
+      return "decrypt"
+    case .generateKey:
+      return "generateKey"
+    case .hash:
+      return "hash"
+    case .sign:
+      return "sign"
+    case .verify:
+      return "verify"
+    case .deriveKey:
+      return "deriveKey"
+    case .store:
+      return "store"
+    case .retrieve:
+      return "retrieve"
+    case .delete:
+      return "delete"
+    case .custom(let operationName, _):
+      return "custom(\(operationName))"
+    }
+  }
+}

--- a/Sources/Security/Core/Types/SecurityResultDTO.swift
+++ b/Sources/Security/Core/Types/SecurityResultDTO.swift
@@ -1,0 +1,89 @@
+import Foundation
+import UmbraCoreTypes
+
+/// Result data transfer object for security operations
+/// Contains the outcome of security operations performed by the security provider
+public struct SecurityResultDTO: Sendable {
+  /// Result status
+  public enum Status: String, Sendable, Equatable {
+    /// Operation completed successfully
+    case success = "Success"
+    /// Operation failed
+    case failure = "Failure"
+    /// Operation requires additional input
+    case needsInput = "NeedsInput"
+    /// Operation partially completed
+    case partial = "Partial"
+  }
+  
+  /// Operation status
+  public let status: Status
+  
+  /// Result data if applicable
+  public let data: SecureBytes?
+  
+  /// Error information if operation failed
+  public let error: Error?
+  
+  /// Additional metadata as key-value pairs
+  public let metadata: [String: String]
+  
+  /// Initialise with operation result
+  /// - Parameters:
+  ///   - status: Operation status
+  ///   - data: Result data (if any)
+  ///   - error: Error information (if any)
+  ///   - metadata: Additional metadata
+  public init(
+    status: Status,
+    data: SecureBytes? = nil,
+    error: Error? = nil,
+    metadata: [String: String] = [:]
+  ) {
+    self.status = status
+    self.data = data
+    self.error = error
+    self.metadata = metadata
+  }
+  
+  /// Create a success result with data
+  /// - Parameter data: The operation result data
+  /// - Returns: A success result DTO
+  public static func success(data: SecureBytes? = nil) -> SecurityResultDTO {
+    SecurityResultDTO(status: .success, data: data, error: nil)
+  }
+  
+  /// Create a failure result with error
+  /// - Parameter error: The error that occurred
+  /// - Returns: A failure result DTO
+  public static func failure(error: Error) -> SecurityResultDTO {
+    SecurityResultDTO(status: .failure, data: nil, error: error)
+  }
+  
+  /// Create a result that requires additional input
+  /// - Parameter metadata: Information about required input
+  /// - Returns: A needs-input result DTO
+  public static func needsInput(metadata: [String: String]) -> SecurityResultDTO {
+    SecurityResultDTO(status: .needsInput, data: nil, error: nil, metadata: metadata)
+  }
+  
+  /// Create a partial result with available data
+  /// - Parameters:
+  ///   - data: The partial result data
+  ///   - metadata: Information about the partial result
+  /// - Returns: A partial result DTO
+  public static func partial(data: SecureBytes, metadata: [String: String]) -> SecurityResultDTO {
+    SecurityResultDTO(status: .partial, data: data, error: nil, metadata: metadata)
+  }
+}
+
+// Extend SecurityResultDTO to conform to Equatable
+extension SecurityResultDTO: Equatable {
+  public static func == (lhs: SecurityResultDTO, rhs: SecurityResultDTO) -> Bool {
+    lhs.status == rhs.status &&
+    lhs.data == rhs.data &&
+    lhs.metadata == rhs.metadata &&
+    // Compare errors by their string descriptions
+    String(describing: lhs.error) == String(describing: rhs.error)
+  }
+}

--- a/Sources/Security/Implementation/Crypto/BUILD.bazel
+++ b/Sources/Security/Implementation/Crypto/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//bazel:swift_rules.bzl", "umbra_swift_library")
+
+# Cryptographic implementations for security services
+umbra_swift_library(
+    name = "Crypto",
+    srcs = glob(
+        ["**/*.swift"],
+        exclude = ["**/*.generated.swift"],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//Sources/Security/Core/Protocols",
+        "//Sources/Security/Core/Types",
+        "//Sources/Security/Core/Errors",
+        "//Sources/UmbraCoreTypes",
+    ],
+)

--- a/Sources/Security/Utils/BUILD.bazel
+++ b/Sources/Security/Utils/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//bazel:swift_rules.bzl", "umbra_swift_library")
+
+# Security utilities and helper functions
+# Provides common utility functions for security operations
+umbra_swift_library(
+    name = "Utils",
+    srcs = glob(
+        ["**/*.swift"],
+        exclude = ["**/*.generated.swift"],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//Sources/Security/Core/Types",
+        "//Sources/UmbraCoreTypes",
+    ],
+)


### PR DESCRIPTION
- Resolved circular dependencies between Security Core modules
- Standardised module import statements to use Bazel target names
- Removed redundant error types in favour of consistent SecurityProtocolError
- Simplified BUILD.bazel dependencies to improve build reliability
- Ensured consistent error handling across all Security protocols

Part of the Security module consolidation effort to improve maintainability and code clarity by establishing a clean hierarchical structure.